### PR TITLE
Change enum type to bool in asm golay decoder

### DIFF
--- a/grc/sattools_asm_golay_decoder.xml
+++ b/grc/sattools_asm_golay_decoder.xml
@@ -30,7 +30,7 @@
   <param>
     <name>CCSDS Randomization</name>
     <key>ccsds_randomize</key>
-    <type>enum</type>
+    <type>bool</type>
     <option>
       <name>Enabled</name>
       <key>True</key>
@@ -44,7 +44,7 @@
   <param>
     <name>CCSDS Reed-Solomon</name>
     <key>ccsds_rs</key>
-    <type>enum</type>
+    <type>bool</type>
     <option>
       <name>Enabled</name>
       <key>True</key>
@@ -58,7 +58,7 @@
   <param>
     <name>CRC32-C</name>
     <key>crc32c</key>
-    <type>enum</type>
+    <type>bool</type>
     <option>
       <name>Enabled</name>
       <key>True</key>


### PR DESCRIPTION
Hello again, we frequently use "Parameter blocks" to configure our flowgraphs. One thing about the enum type is that it doesn't actually let us do that. Changing it to bool type will let us directly modify the value of these parameters in GRC while keeping backward compatibility with already existing flowgraphs. 

cc @anuraaga @kenichi-fukushima